### PR TITLE
Add github action to open issue upon new SNAPHU release

### DIFF
--- a/.github/workflows/check_for_snaphu_updates.yaml
+++ b/.github/workflows/check_for_snaphu_updates.yaml
@@ -1,0 +1,65 @@
+name: Check Latest Version Workflow
+
+on:
+  schedule:
+    # Runs at 00:00 UTC every day
+    - cron: '0 0 * * *'
+
+jobs:
+  check-version-and-update:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install requests beautifulsoup4
+
+    - name: Run the version check script
+      id: version_check
+      run: |
+        python .github/workflows/compare_latest_version.py
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Configure Git
+      if: steps.version_check.outputs.new_version_available == 'true'
+      run: |
+        git config --global user.name 'github-actions'
+        git config --global user.email 'github-actions@github.com'
+
+    - name: Create new branch
+      if: steps.version_check.outputs.new_version_available == 'true'
+      run: |
+        git checkout -b update-snaphu-${{ steps.version_check.outputs.remote_version }}
+
+    # Add steps to modify your code or files to reflect the new version here
+
+    - name: Commit changes
+      if: steps.version_check.outputs.new_version_available == 'true'
+      run: |
+        git commit -am "Update to snaphu ${{ steps.version_check.outputs.remote_version }}"
+
+    - name: Push changes
+      if: steps.version_check.outputs.new_version_available == 'true'
+      run: |
+        git push origin update-snaphu-${{ steps.version_check.outputs.remote_version }}
+
+    - name: Create Pull Request
+      if: steps.version_check.outputs.new_version_available == 'true'
+      uses: peter-evans/create-pull-request@v3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: "Update to snaphu ${{ steps.version_check.outputs.remote_version }}"
+        title: "Update to snaphu ${{ steps.version_check.outputs.remote_version }}"
+        body: |
+          Updating to the latest snaphu version ${{ steps.version_check.outputs.remote_version }}.
+        branch: update-snaphu-${{ steps.version_check.outputs.remote_version }}

--- a/.github/workflows/check_for_snaphu_updates.yaml
+++ b/.github/workflows/check_for_snaphu_updates.yaml
@@ -6,7 +6,7 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  check-version-and-update:
+  check-version-and-create-issue:
     runs-on: ubuntu-latest
 
     steps:
@@ -25,41 +25,17 @@ jobs:
 
     - name: Run the version check script
       id: version_check
-      run: |
-        python .github/workflows/compare_latest_version.py
+      run: python .github/workflows/compare_latest_version.py
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Configure Git
+    - name: Open GitHub Issue if new version is available
       if: steps.version_check.outputs.new_version_available == 'true'
-      run: |
-        git config --global user.name 'github-actions'
-        git config --global user.email 'github-actions@github.com'
-
-    - name: Create new branch
-      if: steps.version_check.outputs.new_version_available == 'true'
-      run: |
-        git checkout -b update-snaphu-${{ steps.version_check.outputs.remote_version }}
-
-    # Add steps to modify your code or files to reflect the new version here
-
-    - name: Commit changes
-      if: steps.version_check.outputs.new_version_available == 'true'
-      run: |
-        git commit -am "Update to snaphu ${{ steps.version_check.outputs.remote_version }}"
-
-    - name: Push changes
-      if: steps.version_check.outputs.new_version_available == 'true'
-      run: |
-        git push origin update-snaphu-${{ steps.version_check.outputs.remote_version }}
-
-    - name: Create Pull Request
-      if: steps.version_check.outputs.new_version_available == 'true'
-      uses: peter-evans/create-pull-request@v3
+      uses: JasonEtco/create-an-issue@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: "Update to snaphu ${{ steps.version_check.outputs.remote_version }}"
-        title: "Update to snaphu ${{ steps.version_check.outputs.remote_version }}"
+        title: "New snaphu version ${{ steps.version_check.outputs.remote_version }} available"
         body: |
-          Updating to the latest snaphu version ${{ steps.version_check.outputs.remote_version }}.
-        branch: update-snaphu-${{ steps.version_check.outputs.remote_version }}
+          There is a new snaphu version available: ${{ steps.version_check.outputs.remote_version }}.
+          Please update the codebase.

--- a/.github/workflows/compare_latest_version.py
+++ b/.github/workflows/compare_latest_version.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+import re
+from pathlib import Path
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup
+
+SNAPHU_URL = "https://web.stanford.edu/group/radar/softwareandlinks/sw/snaphu/"
+
+
+def fetch_stanford_version_url() -> str:
+    """
+    Find the link to the latest version of "snaphu-vXXX.tar.gz" from the given URL.
+
+    Parameters
+    ----------
+    url : str
+        The URL of the webpage to search for the snaphu tarball.
+
+    Returns
+    -------
+    str
+        The URL to the latest version of snaphu tarball if found, otherwise an empty string.
+
+    """
+    response = requests.get(SNAPHU_URL)
+    response.raise_for_status()  # Raise an HTTPError if the HTTP request returned an unsuccessful status code
+
+    # Parse the HTML content
+    soup = BeautifulSoup(response.text, "html.parser")
+    links = soup.find_all("a")
+
+    # Find all .tar.gz files
+    tarball_links = [link for link in links if link.get("href", "").endswith(".tar.gz")]
+
+    # Filter out the links that match the pattern "snaphu-vXXX.tar.gz"
+    snaphu_links = [
+        link for link in tarball_links if "snaphu-v" in link.get("href", "")
+    ]
+
+    if not snaphu_links:
+        return ""
+
+    # Assuming the latest version is the one with the highest version number
+    latest_version_tar_name = sorted(
+        snaphu_links, key=lambda x: x.get("href"), reverse=True
+    )[0].get("href")
+
+    latest_version = re.match(
+        r"snaphu-v(\d+\.\d+\.\d+)", latest_version_tar_name
+    ).group(1)
+    # Join the relative URL with the base URL to form an absolute URL
+    full_code_url = urljoin(SNAPHU_URL, latest_version_tar_name)
+
+    return latest_version, full_code_url
+
+
+def get_current_version_from_github_readme() -> str:
+    """
+    Get the current version of the code from the README file in the given GitHub repository.
+
+
+    Returns
+    -------
+    str
+        The current version of the code as mentioned in the README, or an empty string if not found.
+
+    """
+    # Convert the GitHub repo URL to the raw README URL
+    readme_file = Path(__file__).parent.parent.parent / "README"
+    readme = readme_file.read_text()
+
+    # Use regular expression to find version patterns like 'vX.X.X' or 'X.X.X'
+    for line in readme.splitlines():
+        if version_match := re.match(r"Version\s+(\d+\.\d+\.\d+)", line):
+            return version_match.group(1)
+    else:
+        raise ValueError(f"Failed to parse version from readme: {readme}")
+
+
+if __name__ == "__main__":
+    # Find and print the latest version URL
+    remote_version, code_url = fetch_stanford_version_url()
+    current_version = get_current_version_from_github_readme()
+
+    if remote_version != current_version:
+        print("::set-output name=new_version_available::true")
+        print("::set-output name=remote_version::{remote_version}")
+        print("TODO: Update local code...")
+    else:
+        print("::set-output name=new_version_available::false")
+        print("Local version matches remote: nothing to do")

--- a/.github/workflows/compare_latest_version.py
+++ b/.github/workflows/compare_latest_version.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import os
 import re
 from pathlib import Path
 from urllib.parse import urljoin
@@ -84,10 +85,18 @@ if __name__ == "__main__":
     remote_version, code_url = fetch_stanford_version_url()
     current_version = get_current_version_from_github_readme()
 
-    if remote_version != current_version:
-        print("::set-output name=new_version_available::true")
-        print("::set-output name=remote_version::{remote_version}")
-        print("TODO: Update local code...")
-    else:
-        print("::set-output name=new_version_available::false")
-        print("Local version matches remote: nothing to do")
+    try:
+        if remote_version != current_version:
+            print("::set-output name=new_version_available::true")
+            print("::set-output name=remote_version::{remote_version}")
+            print("New version available: need to update local code...")
+            with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+                print("new_version_available=true", file=fh)
+                print(f"remove_version={remote_version}", file=fh)
+        else:
+            print("Local version matches remote: nothing to do")
+            with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+                print("new_version_available=false", file=fh)
+    except KeyError:
+        # Not in github action context
+        pass


### PR DESCRIPTION
- Adds script which parses the stanford site and sees if the version is different than the version here
```bash
snaphu$ .github/workflows/compare_latest_version.py
Local version matches remote: nothing to do
```
- Attempts a github action that opens an issue upon seeing a difference
  -  Opening the correct PR seemed harder, this was the easier first step
  - I don't know how to test this locally; not sure if you've seen any good options to run github actions locally